### PR TITLE
Fix extraction order

### DIFF
--- a/alf_to_esp.py
+++ b/alf_to_esp.py
@@ -59,8 +59,8 @@ def convert_json_to_yaml(input_file, output_file):
                     if snippet_data:
                         # Transform the data
                         match = {
-                            'replace': snippet_data.get("snippet").strip(),
                             "trigger": prefix + snippet_data.get("keyword").strip() + suffix,
+                            'replace': snippet_data.get("snippet").strip(),
                             "label": snippet_data.get("name")
                         }
                         matches.append(match)


### PR DESCRIPTION
Ensure the resulting .yml file has data populated in the correct order so you end up with something like:

```
- trigger: macos
  replace: macOS
  label: ''
```

Instead of the current situation where you end up with results like what you have below and then need to manually tweak them:

```
- replace: macOS
  trigger: macos
  label: ''
```

